### PR TITLE
Handle Docker push credentials more securely

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ services:
   - docker
 
 env:
-  global:
-    - DOCKER_CONFIG=./.docker
   matrix:
     - TAG=3.2
     - TAG=3.3
@@ -15,9 +13,10 @@ script:
   - make build
   - make test
 
-
 before_deploy:
-  - openssl aes-256-cbc -K "$DOCKER_CONF_key" -iv "$DOCKER_CONF_iv" -in .docker/config.json.enc -out .docker/config.json -d
+  - export DOCKER_CONFIG="${HOME}/.docker"
+  - mkdir -p "$DOCKER_CONFIG"
+  - openssl aes-256-cbc -K "$DOCKER_CONF_key" -iv "$DOCKER_CONF_iv" -in .docker/config.json.enc -out "${DOCKER_CONFIG}/config.json" -d
 
 deploy:
   provider: script
@@ -25,4 +24,3 @@ deploy:
   script: make push
   on:
     branch: master
-


### PR DESCRIPTION
Currently, we load the docker configuration in `.docker`, which *could*
(but hasn't in any of our repos) end up in the Docker image if we ran a
`ADD . somewhere` instruction.

This updates the Travis build file to copy the Docker configuration
outside of the build directory so we can't accidentally `ADD` it in the
Docker image.

---

cc @fancyremarker — as mentioned in the commit comment, this isn't actually a problem right now in any of our repos, but for the sake of not making any mistakes later, I'm going to deploy this update to all our repos that use this builder.