### PR TITLE
Add version 3.5 through 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ env:
     - TAG=3.2
     - TAG=3.3
     - TAG=3.4
+    - TAG=3.5
+    - TAG=3.6
+    - TAG=3.7
+    - TAG=3.8
+    - TAG=3.9
 
 script:
   - make build


### PR DESCRIPTION
Add never versions.   Not updating the `lastest` tag until we consider the following uses of it:

```
baggadonuts/Dockerfile:FROM quay.io/aptible/alpine:latest
docker-registry-proxy/Dockerfile:FROM quay.io/aptible/alpine:latest
elasticsearch-logstash-s3-backup/Dockerfile:FROM quay.io/aptible/alpine:latest
minitron/Dockerfile:FROM quay.io/aptible/alpine
```

There is (within the live retention period of Papertrail) one customer deploying the `latest` tag.