### PR TITLE
Move from Gliderlabs to Libary base.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ env:
     - TAG=3.7
     - TAG=3.8
     - TAG=3.9
+    - TAG=3.10
+    - TAG=3.11
+    - TAG=3.12
 
 script:
   - make build

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -1,4 +1,6 @@
-FROM gliderlabs/alpine:<%= ENV.fetch('TAG') %>
+FROM alpine:<%= ENV.fetch('TAG') %>
+
+COPY apk-install /usr/sbin/
 
 RUN apk-install bash curl \
     && curl -sL https://github.com/sstephenson/bats/archive/master.zip > /tmp/bats.zip \

--- a/apk-install
+++ b/apk-install
@@ -1,0 +1,3 @@
+#!/bin/sh
+apk add --update "$@" && rm -rf /var/cache/apk/*
+


### PR DESCRIPTION
gliderlabs.com appears down/gone, but we can easily switch to the library version.

The only difference is we in many places rely on `apk-install`, which is not in the library version, but easy enough to re-create. https://github.com/gliderlabs/docker-alpine/issues/19